### PR TITLE
fix: remove out status from practice sessions

### DIFF
--- a/src/__tests__/replay-processor.test.ts
+++ b/src/__tests__/replay-processor.test.ts
@@ -191,7 +191,8 @@ describe("getRetiredDrivers", () => {
         Date.parse("2026-03-14T05:10:00.000Z"),
         false,
         [],
-        positions
+        positions,
+        "Race"
       )
     ).toEqual(new Map([[2, "DNS"]]));
   });
@@ -217,9 +218,37 @@ describe("getRetiredDrivers", () => {
         Date.parse("2026-03-14T05:15:30.000Z"),
         false,
         [],
-        positions
+        positions,
+        "Race"
       )
     ).toEqual(new Map([[2, "OUT"]]));
+  });
+
+  it("does not mark practice drivers as OUT", () => {
+    const timing: ReplayTimingSnapshot[] = [
+      { driverNumber: 1, position: 1, currentLap: 20 },
+      { driverNumber: 2, position: 2, currentLap: 10 },
+    ];
+    const positions = [
+      position("2026-03-14T05:00:00.000Z", 1, 1),
+      position("2026-03-14T05:00:00.000Z", 2, 2),
+    ];
+    const laps = [
+      lap("2026-03-14T05:15:00.000Z", 1, 20),
+      lap("2026-03-14T05:10:00.000Z", 2, 10),
+    ];
+
+    expect(
+      getRetiredDrivers(
+        timing,
+        laps,
+        Date.parse("2026-03-14T05:15:30.000Z"),
+        false,
+        [],
+        positions,
+        "Practice"
+      )
+    ).toEqual(new Map());
   });
 
   it("marks Q1 eliminations after the 90 second buffer, including no-data drivers", () => {
@@ -244,7 +273,8 @@ describe("getRetiredDrivers", () => {
       Date.parse("2026-03-14T05:19:31.000Z"),
       true,
       raceControl,
-      positions
+      positions,
+      "Qualifying"
     );
 
     expect(retired.get(20)).toBe("Q1");

--- a/src/app/live/page.tsx
+++ b/src/app/live/page.tsx
@@ -220,7 +220,11 @@ export default function SessionAnalysisPage() {
     return raceStats?.gridVsFinishData ?? [];
   }, [raceStats]);
 
-  const isQuali = sessions?.find((s) => s.session_key === sessionKey)?.session_type === "Qualifying";
+  const selectedSession = availableSessions.find(
+    (s) => s.session_key === sessionKey
+  );
+
+  const isQuali = selectedSession?.session_type === "Qualifying";
 
   // Filtered timing data for replay mode sidebar
   const replayTimingEntries = useMemo(() => {
@@ -247,9 +251,10 @@ export default function SessionAnalysisPage() {
       replayTime,
       isQuali,
       raceControl ?? [],
-      positions ?? []
+      positions ?? [],
+      selectedSession?.session_type
     );
-  }, [replayTimingEntries, laps, replayTime, isQuali, raceControl, positions]);
+  }, [replayTimingEntries, laps, replayTime, isQuali, raceControl, positions, selectedSession?.session_type]);
 
   // Knockout zone: position at which drivers are in danger of elimination.
   // During Q1 the bottom 6 are eliminated, during Q2 the next bottom 6.
@@ -268,12 +273,9 @@ export default function SessionAnalysisPage() {
   const dataError = posErr || intErr || drvErr || lapErr;
   const dataUnavailable = sessionKey && !dataLoading && dataError && !positions;
 
-  const selectedSession = availableSessions.find(
-    (s) => s.session_key === sessionKey
-  );
-
   const isRaceSession = selectedSession?.session_type === "Race" || selectedSession?.session_type === "Sprint";
   const isQualifying = selectedSession?.session_type === "Qualifying" || selectedSession?.session_type === "Sprint Qualifying" || selectedSession?.session_type === "Sprint Shootout";
+  const isPractice = selectedSession?.session_type === "Practice";
 
   // Qualifying: segment times, cutoffs, and knockout positions (all dynamic)
   const qualiCutoffs = useMemo(() => {
@@ -511,7 +513,7 @@ export default function SessionAnalysisPage() {
                   ))}
                 </div>
               ) : (
-                <TimingBoard entries={replayTimingEntries} retiredDrivers={retiredDrivers} isQualifying={isQuali} knockoutPosition={qualiKnockoutPos} />
+                <TimingBoard entries={replayTimingEntries} retiredDrivers={retiredDrivers} isQualifying={isQuali} isPractice={isPractice} knockoutPosition={qualiKnockoutPos} />
               )}
             </div>
             {/* Race control — third on mobile, below map on desktop */}

--- a/src/lib/utils/replay-processor.ts
+++ b/src/lib/utils/replay-processor.ts
@@ -300,7 +300,8 @@ export function getRetiredDrivers(
   replayTime: number | null,
   isQualifyingSession: boolean,
   raceControl: RaceControlMessage[],
-  positions: Position[]
+  positions: Position[],
+  sessionType?: string
 ): Map<number, string> {
   const map = new Map<number, string>();
   if (replayTimingEntries.length === 0) return map;
@@ -355,6 +356,9 @@ export function getRetiredDrivers(
 
     return map;
   }
+
+  const isRaceLikeSession = sessionType === "Race" || sessionType === "Sprint";
+  if (!isRaceLikeSession) return map;
 
   const leaderEntry = replayTimingEntries.find((e) => e.position === 1);
   const leaderLap = leaderEntry?.currentLap ?? 0;


### PR DESCRIPTION
## What

<!-- What does this PR do? -->

## Why

<!-- Why is this change needed? Link the issue: Closes #N -->

## How

<!-- Brief description of the approach, if non-obvious -->

## Checklist

- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Tested on mobile


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of different session types to correctly manage driver status across Race, Qualifying, and Practice sessions.

* **Tests**
  * Expanded test coverage to validate proper behavior for all session types, including Practice scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->